### PR TITLE
add: :n username channelname ex: :n testuser #testchannel (#97)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _test/
 *.swp
 *~
 *.out
+/.gitconfig

--- a/client.go
+++ b/client.go
@@ -55,6 +55,12 @@ func main() {
 				switch idx := strings.Index(cmd, " "); {
 				case cmd[1] == 'd':
 					fmt.Printf(c.String())
+				case cmd[1] == 'n':
+					parts := strings.Split(cmd, " ")
+					username := strings.TrimSpace(parts[1])
+					channelname := strings.TrimSpace(parts[2])
+					_, userIsOn := c.StateTracker().IsOn(channelname, username)
+					fmt.Printf("Checking if %s is in %s Online: %t\n", username, channelname, userIsOn)
 				case cmd[1] == 'f':
 					if len(cmd) > 2 && cmd[2] == 'e' {
 						// enable flooding


### PR DESCRIPTION
Add: :n <nick> <channel> as a command to the example client.

This queries the state tracker for the status of the user on the given channel.